### PR TITLE
Avoid walking if module has no directory

### DIFF
--- a/modules/core/src/Runner.scala
+++ b/modules/core/src/Runner.scala
@@ -9,7 +9,7 @@ object Runner {
     *   list of paths that are missing headers or contain the incorrect headers
     */
   def check(args: HeaderArgs): List[os.RelPath] = {
-    os.walk(args.startPath, args.skip)
+    walkIfExists(args.startPath, args.skip)
       .filter(os.isFile)
       .flatMap { path =>
         val contents = os.read(path)
@@ -26,7 +26,7 @@ object Runner {
     *   list of paths where headers were added
     */
   def create(args: HeaderArgs): List[os.RelPath] = {
-    os.walk(args.startPath, args.skip)
+    walkIfExists(args.startPath, args.skip)
       .filter(os.isFile)
       .flatMap { path =>
         val contents = os.read(path)
@@ -37,5 +37,10 @@ object Runner {
         }
       }
       .toList
+  }
+
+  private def walkIfExists(path: os.Path, skip: os.Path => Boolean) = {
+    if (os.exists(path)) os.walk(path, skip)
+    else IndexedSeq.empty
   }
 }

--- a/modules/mill-plugin/itest/src/01-check-formatted/build.sc
+++ b/modules/mill-plugin/itest/src/01-check-formatted/build.sc
@@ -60,7 +60,7 @@ def verify(): Command[Unit] = T.command {
     os.rel / "nested" / "noHeader.scala"
   )
   val createResult = sut.headerCreate()()
-  if (createResult != expectedFailedPaths)
+  if (createResult.sorted != expectedFailedPaths)
     sys.error(
       s"Expected createResult '$expectedFailedPaths' but was '${createResult}'"
     )

--- a/modules/mill-plugin/itest/src/01-check-formatted/build.sc
+++ b/modules/mill-plugin/itest/src/01-check-formatted/build.sc
@@ -8,6 +8,10 @@ object sut extends HeaderModule {
   def license: HeaderLicense = HeaderLicense.Apache2("2022", "lewisjkl")
 }
 
+object nodir extends HeaderModule {
+  def license: HeaderLicense = HeaderLicense.Apache2("2022", "lewisjkl")
+}
+
 final case class FlatFile(path: os.Path, contents: String)
 
 def flatFiles(p: os.Path): IndexedSeq[FlatFile] = {
@@ -62,5 +66,6 @@ def verify(): Command[Unit] = T.command {
     )
   checkFlatFiles()
   sut.headerCheck()() // now should be fine
+  nodir.headerCheck()()
   ()
 }


### PR DESCRIPTION
This happens when you define a module with no source. It happens, for example, when you build a module only as a way to repackage another module with some changes (like shading the content of the jar, for example)